### PR TITLE
Fix to ensure that random numbers are generated correctly for caching

### DIFF
--- a/src/main/java/com/ragingcoffee/cachingalgorithms/FirstInFirstOutCache.java
+++ b/src/main/java/com/ragingcoffee/cachingalgorithms/FirstInFirstOutCache.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.Queue;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 public final class FirstInFirstOutCache implements CacheMechanism {
 
@@ -22,9 +23,7 @@ public final class FirstInFirstOutCache implements CacheMechanism {
 
     public String loadCache() {
         Random random = new Random();
-        for (int iterator = 0; iterator < CACHE_SIZE; iterator ++) {
-            cache.add(random.nextInt(MEMORY_SIZE + 1));
-        }
+        random.ints(0, MEMORY_SIZE).distinct().limit(CACHE_SIZE).boxed().collect(Collectors.toList()).forEach(cache::add);
         return cache.toString();
     }
 

--- a/src/main/java/com/ragingcoffee/cachingalgorithms/LastInFirstOutCache.java
+++ b/src/main/java/com/ragingcoffee/cachingalgorithms/LastInFirstOutCache.java
@@ -3,6 +3,7 @@ package com.ragingcoffee.cachingalgorithms;
 import java.util.ArrayList;
 import java.util.Stack;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 public final class LastInFirstOutCache implements CacheMechanism {
 
@@ -21,9 +22,7 @@ public final class LastInFirstOutCache implements CacheMechanism {
 
     public String loadCache() {
         Random random = new Random();
-        for (int iterator = 0; iterator < CACHE_SIZE; iterator ++) {
-            cache.add(random.nextInt(MEMORY_SIZE + 1));
-        }
+        random.ints(0, MEMORY_SIZE).distinct().limit(CACHE_SIZE).boxed().collect(Collectors.toList()).forEach(cache::add);
         return cache.toString();
     }
 

--- a/src/main/java/com/ragingcoffee/cachingalgorithms/LeastFrequentlyUsedCache.java
+++ b/src/main/java/com/ragingcoffee/cachingalgorithms/LeastFrequentlyUsedCache.java
@@ -2,7 +2,9 @@ package com.ragingcoffee.cachingalgorithms;
 
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 public final class LeastFrequentlyUsedCache implements CacheMechanism {
 
@@ -21,8 +23,9 @@ public final class LeastFrequentlyUsedCache implements CacheMechanism {
 
     public String loadCache() {
         Random random = new Random();
+        List<Integer> randomValues = random.ints(0, MEMORY_SIZE).distinct().limit(CACHE_SIZE).boxed().collect(Collectors.toList());
         for (int iterator = 0; iterator < CACHE_SIZE; iterator ++) {
-            cache[0][iterator] = random.nextInt(MEMORY_SIZE + 1);
+            cache[0][iterator] = randomValues.get(iterator);
             cache[1][iterator] = 0;
         }
         return Arrays.toString(cache[0]);

--- a/src/main/java/com/ragingcoffee/cachingalgorithms/LeastRecentlyUsedCache.java
+++ b/src/main/java/com/ragingcoffee/cachingalgorithms/LeastRecentlyUsedCache.java
@@ -3,6 +3,7 @@ package com.ragingcoffee.cachingalgorithms;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 public final class LeastRecentlyUsedCache implements CacheMechanism {
 
@@ -21,9 +22,7 @@ public final class LeastRecentlyUsedCache implements CacheMechanism {
 
     public String loadCache() {
         Random random = new Random();
-        for (int iterator = 0; iterator < CACHE_SIZE; iterator ++) {
-            cache.add(random.nextInt(MEMORY_SIZE + 1));
-        }
+        random.ints(0, MEMORY_SIZE).distinct().limit(CACHE_SIZE).boxed().collect(Collectors.toList()).forEach(cache::add);
         return cache.toString();
     }
 

--- a/src/main/java/com/ragingcoffee/cachingalgorithms/MostRecentlyUsedCache.java
+++ b/src/main/java/com/ragingcoffee/cachingalgorithms/MostRecentlyUsedCache.java
@@ -3,6 +3,7 @@ package com.ragingcoffee.cachingalgorithms;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 public final class MostRecentlyUsedCache implements CacheMechanism {
 
@@ -21,9 +22,7 @@ public final class MostRecentlyUsedCache implements CacheMechanism {
 
     public String loadCache() {
         Random random = new Random();
-        for (int iterator = 0; iterator < CACHE_SIZE; iterator ++) {
-            cache.add(random.nextInt(MEMORY_SIZE + 1));
-        }
+        random.ints(0, MEMORY_SIZE).distinct().limit(CACHE_SIZE).boxed().collect(Collectors.toList()).forEach(cache::add);
         return cache.toString();
     }
 

--- a/src/main/java/com/ragingcoffee/cachingalgorithms/RandomReplacementCache.java
+++ b/src/main/java/com/ragingcoffee/cachingalgorithms/RandomReplacementCache.java
@@ -3,6 +3,7 @@ package com.ragingcoffee.cachingalgorithms;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 public final class RandomReplacementCache implements CacheMechanism {
 
@@ -21,9 +22,7 @@ public final class RandomReplacementCache implements CacheMechanism {
 
     public String loadCache() {
         Random random = new Random();
-        for (int iterator = 0; iterator < CACHE_SIZE; iterator ++) {
-            cache.add(random.nextInt(MEMORY_SIZE + 1));
-        }
+        random.ints(0, MEMORY_SIZE).distinct().limit(CACHE_SIZE).boxed().collect(Collectors.toList()).forEach(cache::add);
         return cache.toString();
     }
 


### PR DESCRIPTION
## Description:

This fix aims at tackling the below two points as mentioned in #14 :
- Ensuring that the generation of numbers happens within the range 0-19 and not 1 to 20
- Ensuring that the numbers are unique and do not repeat themselves

Tested the same for all the different caching algorithms and they are working fine.